### PR TITLE
fix: remove invalid log-level shortcut from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can specify qBittorrent connection details using environment variables:
 
 ### Global Options
 
-- `-l, --log-level`: Log level (debug, info, warn, error)
+- `--log-level`: Log level (debug, info, warn, error)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can specify qBittorrent connection details using environment variables:
 
 ### Global Options
 
-- `--log-level`: Log level (debug, info, warn, error)
+- `--log-level`: Log level (debug, info, warn, error) (default "info")
 
 ## Usage
 


### PR DESCRIPTION
Just small fix and addition, I notice the `-l` does not work.